### PR TITLE
 Add the annotation @MavenProperty for fetching maven version id

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,35 @@ In this example, ADP4J will look for an object named `jdbc/dataSource` in JNDI c
 
 Of course, you should have already specified JNDI parameters (context provider, factory, etc) via system properties or a properties file `jndi.properties` in the classpath (standard JNDI configuration).
 
+
+### @MavenProperty
+
+This annotation can be used to load properties from maven configuration.
+
+For the moment, we're only able to get the version number.
+
+We're working on how to get every declared information from MAVEN context into JAVA context.
+
+Attributes of this annotation are described in the following table:
+
+| Attribute     | Type    | Required | Description                                                        |
+|:--------------|:-------:|:--------:|--------------------------------------------------------------------|
+| key           | String  | no       | The key to load from the specified parameter in pom property       |
+| groupId       | String  | yes      | The groupId where is located the pom.xml wanted                    |
+| artifact      | String  | yes      | The artifact where is located the pom.xml wanted                   |
+
+Example :
+
+```java
+@MavenProperty(key="version",groupId="commons-beanutils",artifact="commons-beanutils")
+private String pomVersion;
+```
+
+In this example, we are fetching the actuel version of the commons-beanutils dependency
+
+Note that ADP4J caches maven context loaded from pom.properties for further reuse.
+
+
 ## Using ADP4J in a web environment
 
 Using ADP4J to inject properties in web components is straightforward. Like any other object, all you need is to annotate your instance variable with ADP4J annotations and provide a setter.

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>net.benas</groupId>
     <artifactId>adp4j</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>adp4j</name>
@@ -70,5 +70,6 @@
         </dependency>
 
     </dependencies>
+
 
 </project>

--- a/src/main/java/net/benas/adp4j/annotations/MavenProperty.java
+++ b/src/main/java/net/benas/adp4j/annotations/MavenProperty.java
@@ -1,0 +1,34 @@
+package net.benas.adp4j.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation injects a property from a Maven context in the annotated field.
+ *
+ * @author lhottois (natlantisprog@gmail.com)
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface MavenProperty {
+
+    /**
+     * The field name in MAVEN context.
+     * By default, we get the version ID.
+     * @return The value in MAVEN context
+     */
+    public String key() default "version";
+
+    /**
+     * The artifact of the maven JAR to search
+     */
+    public String artifact() ;
+
+    /**
+     * The groupId of the maven JAR to search
+     */
+    public String groupId() ;
+
+}

--- a/src/main/java/net/benas/adp4j/impl/PropertiesInjectorImpl.java
+++ b/src/main/java/net/benas/adp4j/impl/PropertiesInjectorImpl.java
@@ -54,6 +54,7 @@ public class PropertiesInjectorImpl implements PropertiesInjector {
         annotationProcessors.put(Properties.class, new PropertiesAnnotationProcessor());
         annotationProcessors.put(DBProperty.class, new DBPropertyAnnotationProcessor());
         annotationProcessors.put(JNDIProperty.class, new JNDIPropertyAnnotationProcessor());
+        annotationProcessors.put(MavenProperty.class, new MavenAnnotationProcessor());
     }
 
     @Override

--- a/src/main/java/net/benas/adp4j/processors/MavenAnnotationProcessor.java
+++ b/src/main/java/net/benas/adp4j/processors/MavenAnnotationProcessor.java
@@ -1,0 +1,86 @@
+/*
+ *   The MIT License
+ *
+ *    Copyright (c) 2013, benas (md.benhassine@gmail.com)
+ *
+ *    Permission is hereby granted, free of charge, to any person obtaining a copy
+ *    of this software and associated documentation files (the "Software"), to deal
+ *    in the Software without restriction, including without limitation the rights
+ *    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *    copies of the Software, and to permit persons to whom the Software is
+ *    furnished to do so, subject to the following conditions:
+ *
+ *    The above copyright notice and this permission notice shall be included in
+ *    all copies or substantial portions of the Software.
+ *
+ *    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *    THE SOFTWARE.
+ */
+
+package net.benas.adp4j.processors;
+
+import net.benas.adp4j.annotations.MavenProperty;
+import net.benas.adp4j.api.AnnotationProcessor;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * An annotation processor that loads all properties from a maven pom.
+ *
+ * @author lhottois (natlantisprog@gmail.com)
+ */
+public class MavenAnnotationProcessor extends AbstractAnnotationProcessor implements AnnotationProcessor<MavenProperty> {
+
+    /**
+     * A map holding pom and Properties object serving as a cache.
+     */
+    private Map<String, String> mavenMap = new HashMap<String, String>();
+
+    @Override
+    public void processAnnotation(MavenProperty mavenAnnotation, Field field, Object object) throws Exception {
+
+        // We get the key to find into the pom
+        String key = mavenAnnotation.key().trim();
+        String groupId = mavenAnnotation.groupId().trim();
+        String artifactId = mavenAnnotation.artifact().trim();
+
+        if (key.isEmpty()) {
+            throw new Exception(missingAttributeValue("key", "@MavenProperty", field, object));
+        }
+
+        //check if the maven value is not already loaded
+        String cacheKey = groupId + "." + artifactId + "." + key;
+        if (!mavenMap.containsKey(cacheKey)) {
+            java.util.Properties properties = new java.util.Properties();
+            // We search directly into the META-INF generated property
+            String pathToMaven = "META-INF/maven/" + groupId + "/" + artifactId + "/pom.properties";
+
+            try {
+                InputStream inputStream = object.getClass().getClassLoader().getResourceAsStream(pathToMaven);
+                if (inputStream != null) {
+                    properties.load(inputStream);
+                    Object keyValue = properties.get(key);
+                    String keyValueAnalyzed = String.valueOf(keyValue);
+                    mavenMap.put(cacheKey,keyValueAnalyzed);
+                } else {
+                    throw new Exception(missingSourceFile(pathToMaven, field, object));
+                }
+            } catch (IOException ex) {
+                throw new Exception(missingSourceFile(pathToMaven, field, object), ex);
+            }
+        }
+
+        injectProperty(object, field, key, mavenMap.get(cacheKey));
+
+    }
+
+}

--- a/src/test/java/net/benas/adp4j/test/Bean.java
+++ b/src/test/java/net/benas/adp4j/test/Bean.java
@@ -33,6 +33,9 @@ public class Bean {
     @JNDIProperty("foo.property")
     private String jndiProperty;
 
+    @MavenProperty(key="version",groupId="commons-beanutils",artifact="commons-beanutils")
+    private String pomVersion;
+
     public void setUserHome(String userHome) {
         this.userHome = userHome;
     }
@@ -97,4 +100,11 @@ public class Bean {
         this.jndiProperty = jndiProperty;
     }
 
+    public String getPomVersion() {
+        return pomVersion;
+    }
+
+    public void setPomVersion(String pomVersion) {
+        this.pomVersion = pomVersion;
+    }
 }

--- a/src/test/java/net/benas/adp4j/test/PropertiesInjectorTest.java
+++ b/src/test/java/net/benas/adp4j/test/PropertiesInjectorTest.java
@@ -8,6 +8,7 @@ import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 
 import javax.naming.Context;
 import javax.naming.InitialContext;
+import java.io.InputStream;
 import java.util.Properties;
 import java.util.ResourceBundle;
 
@@ -54,6 +55,11 @@ public class PropertiesInjectorTest {
     @Test
     public void testSystemPropertyDefaultValueInjection() throws Exception {
         Assert.assertEquals("default", bean.getValue()); //test default value injection
+    }
+
+    @Test
+    public void testSystemMavenVersionValueInjection() throws Exception {
+        Assert.assertEquals("1.8.3", bean.getPomVersion()); //test maven value injection
     }
 
     @Test


### PR DESCRIPTION
  MavenProperty.java > Declaration of the annotation with 3 key values ( key searched, the groupId et the Artifact where is the pom wanted )

  PropertiesInjectorImpl.java > We add our new Annotation
  MavenAnnotationProcessor.java > The gear process of the annotation which is fetching into META-INF datas the version information

  FOR TESTS :
  Bean.java > we add pomVersion attribute wich contains via @MavenProperty the key version of commons-beanutils dependency
  PropertiesInjectorTest.java > We assert that the version ID is correctly fetched

  pom.xml > We upgrade to 1.1-SNAPSHOT
  README > Add of some explanations about the new @MavenProperty annotation
