### PR TITLE
Changed the resource loading to the base class loader.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     </parent>
 
     <groupId>org.jeasy</groupId>
-    <artifactId>easy-props</artifactId>
+    <artifactId>easy-props-ext</artifactId>
     <version>2.1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     </parent>
 
     <groupId>org.jeasy</groupId>
-    <artifactId>easy-props-ext</artifactId>
+    <artifactId>easy-props</artifactId>
     <version>2.1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 

--- a/src/main/java/org/jeasy/props/processors/AbstractAnnotationProcessor.java
+++ b/src/main/java/org/jeasy/props/processors/AbstractAnnotationProcessor.java
@@ -1,8 +1,8 @@
-/*
+/**
  * The MIT License
- * <p>
+ * 
  * Copyright (c) 2017, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
- * <p>
+ * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights

--- a/src/main/java/org/jeasy/props/processors/AbstractAnnotationProcessor.java
+++ b/src/main/java/org/jeasy/props/processors/AbstractAnnotationProcessor.java
@@ -1,25 +1,25 @@
-/**
+/*
  * The MIT License
- *
- *   Copyright (c) 2017, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
- *
- *   Permission is hereby granted, free of charge, to any person obtaining a copy
- *   of this software and associated documentation files (the "Software"), to deal
- *   in the Software without restriction, including without limitation the rights
- *   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- *   copies of the Software, and to permit persons to whom the Software is
- *   furnished to do so, subject to the following conditions:
- *
- *   The above copyright notice and this permission notice shall be included in
- *   all copies or substantial portions of the Software.
- *
- *   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- *   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- *   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- *   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- *   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- *   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- *   THE SOFTWARE.
+ * <p>
+ * Copyright (c) 2017, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ * <p>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * <p>
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * <p>
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
  */
 package org.jeasy.props.processors;
 
@@ -41,8 +41,8 @@ import static java.lang.String.format;
  */
 public abstract class AbstractAnnotationProcessor<A extends Annotation> implements AnnotationProcessor<A> {
 
-    public static final String FILE_RESOURCE_PREFIX = "file:";
-    public static final String CLASSPATH_RESOURCE_PREFIX = "classpath:";
+    private static final String FILE_RESOURCE_PREFIX = "file:";
+    private static final String CLASSPATH_RESOURCE_PREFIX = "classpath:";
 
     /**
      * Constructs an error message to signal missing annotation attribute value.
@@ -77,14 +77,14 @@ public abstract class AbstractAnnotationProcessor<A extends Annotation> implemen
      * @return the resource as {@link InputStream}
      * @throws IOException when an error occurs during resource loading
      */
-    protected InputStream getResourceAsStream(final String resource) throws IOException {
+    InputStream getResourceAsStream(final String resource) throws IOException {
         InputStream resourceAsStream;
         if (resource.startsWith(FILE_RESOURCE_PREFIX)) {
             resourceAsStream = new FileInputStream(extractPath(resource));
         } else if (resource.startsWith(CLASSPATH_RESOURCE_PREFIX)) {
-            resourceAsStream = this.getClass().getClassLoader().getResourceAsStream(extractPath(resource));
+            resourceAsStream = ClassLoader.getSystemClassLoader().getResourceAsStream(extractPath(resource));
         } else { // by default, it is a classpath resource
-            resourceAsStream = this.getClass().getClassLoader().getResourceAsStream(resource);
+            resourceAsStream = ClassLoader.getSystemClassLoader().getResourceAsStream(resource);
         }
         return resourceAsStream;
     }


### PR DESCRIPTION
Hi Mahmoud,

Just changed the resource loading in the annotation processor. When dynamically attaching the class loader for the base classes, and those that are added to the boot class path search, don't have a class loader at attach time, so the resource lookup fails. Strange case, I know.

Regards,
Michael